### PR TITLE
Use protocol-relative URL

### DIFF
--- a/jquery.challonge.js
+++ b/jquery.challonge.js
@@ -20,7 +20,7 @@
       Challonge.prototype._sourceWithOptions = function() {
         var subdomain;
         subdomain = this.subdomain ? "" + this.subdomain + "." : '';
-        return "http://" + subdomain + "challonge.com/" + this.tournamentUrl + "/module?" + ($.param(this.options));
+        return "//" + subdomain + "challonge.com/" + this.tournamentUrl + "/module?" + ($.param(this.options));
       };
 
       Challonge.prototype._$iframe = function() {

--- a/jquery.challonge.js.coffee
+++ b/jquery.challonge.js.coffee
@@ -14,7 +14,7 @@ $.fn.challonge = (tournamentUrl, options) ->
 
     _sourceWithOptions: =>
       subdomain = if @subdomain then "#{@subdomain}." else ''
-      "http://#{subdomain}challonge.com/#{@tournamentUrl}/module?#{$.param(@options)}"
+      "//#{subdomain}challonge.com/#{@tournamentUrl}/module?#{$.param(@options)}"
 
     _$iframe: =>
       $("<iframe src='#{@_sourceWithOptions()}' width='100%' height='#{@height}' frameborder='0' scrolling='auto' allowtransparency='true' />")


### PR DESCRIPTION
Using a protocol-relative URL for the `<iframe>` will prevent security warnings on browsers when loading inside secured pages.